### PR TITLE
Enforce development-based branching in CI workflows

### DIFF
--- a/.github/workflows/development-ci.yml
+++ b/.github/workflows/development-ci.yml
@@ -1,0 +1,40 @@
+name: Development CI
+
+on:
+  pull_request:
+    branches: [development]
+  push:
+    branches: [development]
+
+jobs:
+  build-and-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enforce branches are based on development
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin development
+          if ! git merge-base --is-ancestor origin/development HEAD; then
+            echo "Feature branches must be based on the development branch."
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -1,0 +1,44 @@
+name: Main Release Gate
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build-and-lint:
+    name: Production checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block direct pushes to main
+        if: github.event_name == 'push'
+        run: |
+          echo "Direct pushes to main are blocked. Open a PR from development instead."
+          exit 1
+
+      - name: Enforce development source
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ "$GITHUB_HEAD_REF" != "development" ]; then
+            echo "PRs to main must originate from the development branch."
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+dist/
+.vite/
+.env
+.env.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.DS_Store


### PR DESCRIPTION
## Summary
- require pull requests into `development` to include the current `development` history, ensuring feature branches are based on it
- block direct pushes to `main` and reiterate that only PRs from `development` are accepted for production

## Testing
- npm run lint
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dd0a4b404832ba95fa4b4f243f510)